### PR TITLE
fix: roles.sh add/remove Discord write path

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -15,6 +15,7 @@ Conversational self-serve for **curated game-access roles** only. The same role 
 3. **Only the talking user.** Always pass their Discord user ID as `caller_discord_id`. Never change someone else's roles.
 4. **Do not invent role IDs.** Only use IDs from this skill's tools.
 5. If they ask for a non-game role: refuse briefly ("that is not a self-serve game role") and point them at `/get-roles` for game roles. Do not name or hint at privileged roles.
+6. **You CAN flip game roles from chat.** When they name a game and want access, run `roles.sh add` (after unique `lookup`). Do **not** say you cannot flip it. Do **not** send them to `#get-roles-here`. Prefer `/get-roles` only for browsing many roles.
 
 ## When to use
 
@@ -81,11 +82,12 @@ You may pass a catalog `roleId` snowflake instead of a label. Non-catalog snowfl
 ## How to respond
 
 1. Resolve the inbound Discord user ID; that is always `caller_discord_id`.
-2. For named games: `lookup`, then `add`/`remove` when unique and they clearly want the change.
+2. For named games they want to play: `lookup`, then **immediately** `add` when the match is unique (they already asked for the change). Do not stop after naming the role.
 3. Prefer the tool `message` field; keep replies to 1-3 friendly lines.
-4. Point at `/get-roles` for browsing or multi-role menus. Do **not** send people to the old `#get-roles-here` reaction board as the primary path.
+4. Point at `/get-roles` for browsing or multi-role menus. Never direct people to `#get-roles-here` for self-serve.
 5. After a successful `add`, you may optionally use the `zordon-api` skill (`/games/schedule?days=7` and `/channels`) to mention upcoming games that match the new role. If lookup fails, omit games (do not say you could not look them up).
 6. Discord `50013` / Missing Permissions: say Zordon cannot assign that game role until the bot role is above it in Server Settings; still name the game role they asked for.
+7. Catalog labels are the source of truth (e.g. **Dragon Delves**). Do not invent alternate Discord role names like "Dragon Slayers".
 
 ## Catalog sync
 

--- a/tools/roles.sh
+++ b/tools/roles.sh
@@ -40,7 +40,12 @@ if [[ ! -f "$CATALOG_FILE" ]]; then
 fi
 
 run_py() {
-  PYTHONPATH="${LIB}${PYTHONPATH:+:$PYTHONPATH}" python3 - "$@"
+  # Read a Python program from stdin (heredoc). Do not use for -c one-liners.
+  PYTHONPATH="${LIB}${PYTHONPATH:+:$PYTHONPATH}" python3 -
+}
+
+run_py_c() {
+  PYTHONPATH="${LIB}${PYTHONPATH:+:$PYTHONPATH}" python3 -c "$1"
 }
 
 detect_guild_id() {
@@ -103,7 +108,7 @@ print(json.dumps({"error": "Discord API error", "status": int(os.environ["HTTP_C
 
 case "$ACTION" in
   catalog)
-    run_py - <<'PY'
+    run_py <<'PY'
 import json, sys
 from catalog import flatten_roles, load_catalog
 catalog = load_catalog()
@@ -114,7 +119,7 @@ PY
 
   lookup)
     QUERY="${1:?Usage: roles.sh lookup <query>}"
-    QUERY="$QUERY" run_py - <<'PY'
+    QUERY="$QUERY" run_py <<'PY'
 import json, os
 from catalog import load_catalog
 from resolve import lookup_catalog
@@ -155,7 +160,7 @@ PY
     fi
     GUILD_ID="$(detect_guild_id)"
     MEMBER_JSON=$(discord_request GET "/guilds/${GUILD_ID}/members/${CALLER_ID}") || exit 1
-    MEMBER_JSON="$MEMBER_JSON" CALLER_ID="$CALLER_ID" run_py - <<'PY'
+    MEMBER_JSON="$MEMBER_JSON" CALLER_ID="$CALLER_ID" run_py <<'PY'
 import json, os
 from catalog import filter_member_roles_to_catalog, load_catalog
 
@@ -183,8 +188,9 @@ PY
     ROLE_QUERY="${2:?Usage: roles.sh ${ACTION} <caller_discord_id> <role_id_or_label>}"
 
     # Gate BEFORE any Discord write (and before requiring token for resolve failures)
+    set +e
     GATE_JSON=$(
-      CALLER_ID="$CALLER_ID" ROLE_QUERY="$ROLE_QUERY" run_py - <<'PY'
+      CALLER_ID="$CALLER_ID" ROLE_QUERY="$ROLE_QUERY" run_py <<'PY'
 import json, os, sys
 from catalog import load_catalog
 from gates import gate_write
@@ -194,23 +200,26 @@ result = gate_write(catalog, os.environ["CALLER_ID"], os.environ["ROLE_QUERY"])
 print(json.dumps(result))
 sys.exit(0 if result.get("ok") else 2)
 PY
-    ) || {
+    )
+    GATE_RC=$?
+    set -e
+    if [[ "$GATE_RC" -ne 0 ]]; then
       echo "$GATE_JSON"
       exit 1
-    }
+    fi
 
     if [[ -z "${DISCORD_BOT_TOKEN:-}" ]]; then
       json_error "DISCORD_BOT_TOKEN is not set"
     fi
 
     GUILD_ID="$(detect_guild_id)"
-    ROLE_ID=$(echo "$GATE_JSON" | run_py -c 'import json,sys; print(json.load(sys.stdin)["role"]["roleId"])')
-    ROLE_LABEL=$(echo "$GATE_JSON" | run_py -c 'import json,sys; print(json.load(sys.stdin)["role"]["label"])')
-    GENERAL_CH=$(echo "$GATE_JSON" | run_py -c 'import json,sys; print(json.load(sys.stdin)["role"].get("generalChannelId") or "")')
+    ROLE_ID=$(GATE_JSON="$GATE_JSON" run_py_c 'import json,os; print(json.loads(os.environ["GATE_JSON"])["role"]["roleId"])')
+    ROLE_LABEL=$(GATE_JSON="$GATE_JSON" run_py_c 'import json,os; print(json.loads(os.environ["GATE_JSON"])["role"]["label"])')
+    GENERAL_CH=$(GATE_JSON="$GATE_JSON" run_py_c 'import json,os; print(json.loads(os.environ["GATE_JSON"])["role"].get("generalChannelId") or "")')
 
     if [[ "$ACTION" == "add" ]]; then
       discord_request PUT "/guilds/${GUILD_ID}/members/${CALLER_ID}/roles/${ROLE_ID}" >/dev/null || exit 1
-      GENERAL_CH="$GENERAL_CH" ROLE_LABEL="$ROLE_LABEL" ROLE_ID="$ROLE_ID" CALLER_ID="$CALLER_ID" run_py - <<'PY'
+      GENERAL_CH="$GENERAL_CH" ROLE_LABEL="$ROLE_LABEL" ROLE_ID="$ROLE_ID" CALLER_ID="$CALLER_ID" run_py <<'PY'
 import json, os
 channel = os.environ.get("GENERAL_CH") or ""
 label = os.environ["ROLE_LABEL"]
@@ -230,7 +239,7 @@ print(json.dumps({
 PY
     else
       discord_request DELETE "/guilds/${GUILD_ID}/members/${CALLER_ID}/roles/${ROLE_ID}" >/dev/null || exit 1
-      GENERAL_CH="$GENERAL_CH" ROLE_LABEL="$ROLE_LABEL" ROLE_ID="$ROLE_ID" CALLER_ID="$CALLER_ID" run_py - <<'PY'
+      GENERAL_CH="$GENERAL_CH" ROLE_LABEL="$ROLE_LABEL" ROLE_ID="$ROLE_ID" CALLER_ID="$CALLER_ID" run_py <<'PY'
 import json, os
 channel = os.environ.get("GENERAL_CH") or ""
 label = os.environ["ROLE_LABEL"]


### PR DESCRIPTION
## Summary
- Fix `roles.sh` add/remove: gate JSON was executed as Python (`true` NameError), so Discord PUT/DELETE never ran
- SKILL: must run `add` when user asks for a game; no `#get-roles-here`; use catalog labels only

## Test plan
- [x] unit tests
- [x] refuse non-catalog add
- [x] unique add reaches token/Discord step
- [ ] live `add` for Dragon Delves on VPS

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Restores live Discord role add/remove for catalog-gated self-serve; changes are scoped to the helper script and agent instructions, with gating unchanged before writes.
> 
> **Overview**
> **Fixes a broken Discord write path** in `roles.sh` where `add`/`remove` never reached PUT/DELETE. `run_py` incorrectly passed a stray `-` into `python3`, and piping gate JSON through the same helper tried to run that JSON as Python (e.g. `true` → `NameError`). The script now uses **`run_py` for heredocs** and **`run_py_c` for one-liners**, updates all call sites, and **handles gate failures explicitly** with `GATE_RC` instead of relying on a brittle `||` block.
> 
> **SKILL.md** now tells the agent to **actually grant game roles in chat** (`lookup` → immediate `add` on a unique match), to **stop deferring to `#get-roles-here`**, and to **stick to catalog labels** (no invented role names).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b91386fb3e6ec4e7f59a0639676bc504eba96f57. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->