### PR TITLE
fix: clearer 50013 message for role grants

### DIFF
--- a/tools/roles.sh
+++ b/tools/roles.sh
@@ -101,8 +101,14 @@ try:
     details = json.loads(body) if body else body
 except Exception:
     details = body
-print(json.dumps({"error": "Discord API error", "status": int(os.environ["HTTP_CODE"]), "details": details}))
-' >&2
+payload = {"error": "Discord API error", "status": int(os.environ["HTTP_CODE"]), "details": details}
+if int(os.environ["HTTP_CODE"]) == 403:
+    payload["message"] = (
+        "Zordon cannot assign that game role yet: the bot role must sit above "
+        "the game role in Server Settings > Roles. Ask an admin to fix hierarchy."
+    )
+print(json.dumps(payload, indent=2))
+'
   return 1
 }
 


### PR DESCRIPTION
## Summary
- Print Discord Missing Permissions (50013) as JSON on stdout with a hierarchy fix message for the agent

## Note
Live add reaches Discord; all 16 catalog roles currently sit above the bot role (pos 1), so grants fail until Server Settings hierarchy is fixed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Shell-only change to Discord error formatting and messaging; no changes to catalog gating or role grant logic.
> 
> **Overview**
> Improves how **`discord_request`** reports failed Discord API calls in `tools/roles.sh`.
> 
> On non-success responses, error output is now structured JSON with **`indent=2`**, still including `error`, `status`, and `details`. When the HTTP status is **403**, it also adds a **`message`** telling admins to place the bot role above the target game role in **Server Settings > Roles** so Zordon can assign curated game roles.
> 
> The error JSON is emitted on **stdout** (previously redirected to stderr), matching the goal of surfacing hierarchy/permission failures clearly to the OpenClaw agent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ac0ccc709c36d7a67eb4bdfe3cde5a483940359. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->