### PR TITLE
fix: surface role-write Discord errors to the agent

### DIFF
--- a/tools/roles.sh
+++ b/tools/roles.sh
@@ -224,7 +224,14 @@ PY
     GENERAL_CH=$(GATE_JSON="$GATE_JSON" run_py_c 'import json,os; print(json.loads(os.environ["GATE_JSON"])["role"].get("generalChannelId") or "")')
 
     if [[ "$ACTION" == "add" ]]; then
-      discord_request PUT "/guilds/${GUILD_ID}/members/${CALLER_ID}/roles/${ROLE_ID}" >/dev/null || exit 1
+      set +e
+      DISCORD_RESP=$(discord_request PUT "/guilds/${GUILD_ID}/members/${CALLER_ID}/roles/${ROLE_ID}")
+      DISCORD_RC=$?
+      set -e
+      if [[ "$DISCORD_RC" -ne 0 ]]; then
+        [[ -n "$DISCORD_RESP" ]] && echo "$DISCORD_RESP"
+        exit 1
+      fi
       GENERAL_CH="$GENERAL_CH" ROLE_LABEL="$ROLE_LABEL" ROLE_ID="$ROLE_ID" CALLER_ID="$CALLER_ID" run_py <<'PY'
 import json, os
 channel = os.environ.get("GENERAL_CH") or ""
@@ -244,7 +251,14 @@ print(json.dumps({
 }, indent=2))
 PY
     else
-      discord_request DELETE "/guilds/${GUILD_ID}/members/${CALLER_ID}/roles/${ROLE_ID}" >/dev/null || exit 1
+      set +e
+      DISCORD_RESP=$(discord_request DELETE "/guilds/${GUILD_ID}/members/${CALLER_ID}/roles/${ROLE_ID}")
+      DISCORD_RC=$?
+      set -e
+      if [[ "$DISCORD_RC" -ne 0 ]]; then
+        [[ -n "$DISCORD_RESP" ]] && echo "$DISCORD_RESP"
+        exit 1
+      fi
       GENERAL_CH="$GENERAL_CH" ROLE_LABEL="$ROLE_LABEL" ROLE_ID="$ROLE_ID" CALLER_ID="$CALLER_ID" run_py <<'PY'
 import json, os
 channel = os.environ.get("GENERAL_CH") or ""


### PR DESCRIPTION
## Summary
- Stop discarding stdout from failed Discord role PUT/DELETE so 50013 messages reach OpenClaw

## Test plan
- [x] failed add prints hierarchy JSON

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small control-flow change on error paths only; success behavior for role add/remove is unchanged.
> 
> **Overview**
> **Failed `add`/`remove` role writes no longer swallow Discord API output.** Instead of piping `discord_request` to `/dev/null` and exiting immediately, the script captures the PUT/DELETE response and return code (with `set +e` around the call) and **prints the JSON error body on failure** before exiting.
> 
> That lets OpenClaw see structured errors from `discord_request` (e.g. hierarchy **403** guidance or code **50013**) instead of a silent non-zero exit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9922d2f365cbf0d046a90eccdbb644a5571e692c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->