### PR TITLE
fix: force roles.sh path; ban #get-roles-here fallback

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -12,6 +12,7 @@ Conversational self-serve for **curated game-access roles** only. The same role 
 
 1. **Game-access catalog only.** Never add/remove staff, admin, moderator, color, nitro/boost, mute, `@everyone`, bot-managed, or any role not returned by `catalog` / `lookup`.
 2. **Never use `discord-manage` `role-add` / `role-remove` for players.** That skill is owner-only and can touch any role.
+2b. **Never use the Discord `message` tool `role-add` / `role-remove` / `role-info` for this.** Always use `roles.sh` so the catalog allowlist applies. If `roles.sh add` returns 50013, report the hierarchy message from the tool. Do not invent a `#get-roles-here` workaround.
 3. **Only the talking user.** Always pass their Discord user ID as `caller_discord_id`. Never change someone else's roles.
 4. **Do not invent role IDs.** Only use IDs from this skill's tools.
 5. If they ask for a non-game role: refuse briefly ("that is not a self-serve game role") and point them at `/get-roles` for game roles. Do not name or hint at privileged roles.
@@ -86,7 +87,7 @@ You may pass a catalog `roleId` snowflake instead of a label. Non-catalog snowfl
 3. Prefer the tool `message` field; keep replies to 1-3 friendly lines.
 4. Point at `/get-roles` for browsing or multi-role menus. Never direct people to `#get-roles-here` for self-serve.
 5. After a successful `add`, you may optionally use the `zordon-api` skill (`/games/schedule?days=7` and `/channels`) to mention upcoming games that match the new role. If lookup fails, omit games (do not say you could not look them up).
-6. Discord `50013` / Missing Permissions: say Zordon cannot assign that game role until the bot role is above it in Server Settings; still name the game role they asked for.
+6. Discord `50013` / Missing Permissions: quote the tool `message` (bot role hierarchy). Name the **catalog game label** (e.g. **Dragon Delves**). Never say "grab it in `#get-roles-here`".
 7. Catalog labels are the source of truth (e.g. **Dragon Delves**). Do not invent alternate Discord role names like "Dragon Slayers".
 
 ## Catalog sync


### PR DESCRIPTION
## Summary
- Forbid Discord `message` tool role-add/role-remove for player self-serve
- On 50013, use tool hierarchy message; never send people to `#get-roles-here`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only skill guidance with no runtime or security logic changes.
> 
> **Overview**
> Updates **role-helper** agent policy in `SKILL.md` so game-access changes always go through **`roles.sh`** (catalog allowlist), not the Discord **`message`** tool’s `role-add` / `role-remove` / `role-info`.
> 
> Adds mandatory red line **2b** and tightens **50013** handling: quote the tool’s hierarchy `message`, use **catalog game labels**, and **never** redirect users to `#get-roles-here` as a workaround when assignment fails.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e030c87bfe144a307d22b78406cdbcec0e342b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->