### PR TITLE
feat: menu-style role change reply with open games

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -80,15 +80,30 @@ You may pass a catalog `roleId` snowflake instead of a label. Non-catalog snowfl
 
 **Confirm:** if `lookup` returns a unique match, you may `add`/`remove`. If ambiguous, list options and wait. Do not dump the full catalog unless they ask to browse (prefer `/get-roles` for browsing).
 
-## How to respond
+## How to respond after add / remove
 
-1. Resolve the inbound Discord user ID; that is always `caller_discord_id`.
-2. For named games they want to play: `lookup`, then **immediately** `add` when the match is unique (they already asked for the change). Do not stop after naming the role.
-3. Prefer the tool `message` field; keep replies to 1-3 friendly lines.
-4. Point at `/get-roles` for browsing or multi-role menus. Never direct people to `#get-roles-here` for self-serve.
-5. After a successful `add`, you may optionally use the `zordon-api` skill (`/games/schedule?days=7` and `/channels`) to mention upcoming games that match the new role. If lookup fails, omit games (do not say you could not look them up).
-6. Discord `50013` / Missing Permissions: quote the tool `message` (bot role hierarchy). Name the **catalog game label** (e.g. **Dragon Delves**). Never say "grab it in `#get-roles-here`".
-7. Catalog labels are the source of truth (e.g. **Dragon Delves**). Do not invent alternate Discord role names like "Dragon Slayers".
+Post the tool `message` field **as-is** (same shape as the `/get-roles` menu bot). It already includes only non-empty sections:
+
+```
+**Added:** Dragon Delves
+**Gained access to:** <#channelId>
+
+**Open games (next 7 days):**
+- Dragon Delves - A Baker's Doesn't (<t:…:F>, <t:…:R>)
+```
+
+or
+
+```
+**Removed:** Pirate Borg
+**Lost access to:** <#channelId>
+```
+
+Rules:
+- Do not rewrite into a different format.
+- Do not invent games. If there is no **Open games** section, omit games entirely (do not say you could not look them up).
+- Catalog labels only (e.g. **Dragon Delves**), never Discord nicknames like "Dragon Slayers".
+- Discord `50013`: quote the tool `message` about bot role hierarchy. Never send people to `#get-roles-here`.
 
 ## Catalog sync
 
@@ -104,4 +119,4 @@ Then redeploy this skill to the Zordon workspace.
 
 - `DISCORD_BOT_TOKEN` (required for `status` / `add` / `remove`)
 - Optional: `DISCORD_GUILD_ID` (defaults from OpenClaw config, else FutureHax guild)
-- Optional for post-grant schedule hints: `ZORDON_API_URL`, `ZORDON_API_KEY` via `zordon-api`
+- Optional: `ZORDON_API_URL`, `ZORDON_API_KEY` (used after `add` for 7-day open games; soft-fails if missing)

--- a/lib/games.py
+++ b/lib/games.py
@@ -1,0 +1,120 @@
+"""Match upcoming games to catalog role IDs (same rules as Zordon role menus)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+LOOKAHEAD_DAYS = 7
+
+
+def mapping_matches_game(mapping: dict[str, Any], game: dict[str, Any]) -> bool:
+    title = (game.get("title") or "").lower()
+    system_obj = game.get("system") or {}
+    system = (system_obj.get("name") if isinstance(system_obj, dict) else None) or game.get("systemName") or ""
+    system = str(system).lower()
+    game_name = (mapping.get("gameName") or "").strip().lower()
+    system_name = (mapping.get("systemName") or "").strip().lower()
+
+    if game_name:
+        return (
+            title == game_name
+            or title.startswith(f"{game_name}:")
+            or title.startswith(f"{game_name} -")
+            or title.startswith(f"{game_name} ")
+        )
+    if system_name:
+        return system == system_name
+    return False
+
+
+def match_games_to_role_ids(
+    games: list[dict[str, Any]],
+    mappings: list[dict[str, Any]],
+    role_ids: list[str],
+) -> list[dict[str, Any]]:
+    wanted = set(role_ids)
+    relevant = [
+        m
+        for m in mappings
+        if m.get("interestedGroupId") and m["interestedGroupId"] in wanted
+    ]
+    matched: list[dict[str, Any]] = []
+    seen: set[Any] = set()
+    for game in games:
+        key = game.get("id") or game.get("title")
+        if key in seen:
+            continue
+        if any(mapping_matches_game(m, game) for m in relevant):
+            seen.add(key)
+            matched.append(game)
+    return matched
+
+
+def filter_games_in_lookahead(
+    games: list[dict[str, Any]],
+    *,
+    now: datetime | None = None,
+    days: int = LOOKAHEAD_DAYS,
+) -> list[dict[str, Any]]:
+    now = now or datetime.now(timezone.utc)
+    if now.tzinfo is None:
+        now = now.replace(tzinfo=timezone.utc)
+    end = now + timedelta(days=days)
+    out: list[dict[str, Any]] = []
+    for game in games:
+        raw = game.get("nextSession")
+        if not raw:
+            continue
+        try:
+            session = datetime.fromisoformat(str(raw).replace("Z", "+00:00"))
+        except ValueError:
+            continue
+        if session.tzinfo is None:
+            session = session.replace(tzinfo=timezone.utc)
+        if now <= session <= end:
+            out.append(game)
+    return out
+
+
+def format_game_line(game: dict[str, Any]) -> str:
+    title = game.get("title") or "Untitled"
+    raw = game.get("nextSession")
+    if not raw:
+        return f"- {title}"
+    try:
+        session = datetime.fromisoformat(str(raw).replace("Z", "+00:00"))
+        if session.tzinfo is None:
+            session = session.replace(tzinfo=timezone.utc)
+        unix = int(session.timestamp())
+        return f"- {title} (<t:{unix}:F>, <t:{unix}:R>)"
+    except ValueError:
+        return f"- {title}"
+
+
+def format_adjustment_message(
+    *,
+    action: str,
+    label: str,
+    general_channel_id: str = "",
+    upcoming_games: list[dict[str, Any]] | None = None,
+) -> str:
+    """Mirror Zordon role-menu copy: Added/Removed + Gained/Lost access + optional games."""
+    lines: list[str] = []
+    channel_mention = f"<#{general_channel_id}>" if general_channel_id else ""
+
+    if action == "add":
+        lines.append(f"**Added:** {label}")
+        if channel_mention:
+            lines.append(f"**Gained access to:** {channel_mention}")
+        games = upcoming_games or []
+        if games:
+            lines.append("")
+            lines.append("**Open games (next 7 days):**")
+            lines.extend(format_game_line(g) for g in games)
+    else:
+        lines.append(f"**Removed:** {label}")
+        if channel_mention:
+            lines.append(f"**Lost access to:** {channel_mention}")
+
+    return "\n".join(lines)

--- a/tests/test_games.py
+++ b/tests/test_games.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Tests for game matching and reply formatting."""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "lib"))
+
+from games import (  # noqa: E402
+    filter_games_in_lookahead,
+    format_adjustment_message,
+    match_games_to_role_ids,
+)
+
+
+class MatchTests(unittest.TestCase):
+    def test_title_prefix_and_exact(self):
+        mappings = [
+            {"gameName": "Dragon Delves", "interestedGroupId": "role-dd"},
+            {"gameName": "Tomb of Annihilation", "interestedGroupId": "role-tomb"},
+        ]
+        games = [
+            {"id": "1", "title": "Dragon Delves - A Baker's Doesn't"},
+            {"id": "2", "title": "Tomb of Annihilation"},
+            {"id": "3", "title": "Something Else"},
+        ]
+        matched = match_games_to_role_ids(games, mappings, ["role-dd"])
+        self.assertEqual([g["id"] for g in matched], ["1"])
+
+    def test_system_fallback(self):
+        mappings = [{"systemName": "Pirate Borg", "gameName": "", "interestedGroupId": "role-pb"}]
+        games = [
+            {"id": "1", "title": "Open table", "system": {"name": "Pirate Borg"}},
+            {"id": "2", "title": "Other", "system": {"name": "D&D 5E"}},
+        ]
+        matched = match_games_to_role_ids(games, mappings, ["role-pb"])
+        self.assertEqual([g["id"] for g in matched], ["1"])
+
+
+class LookaheadTests(unittest.TestCase):
+    def test_filters_window(self):
+        now = datetime(2026, 8, 25, tzinfo=timezone.utc)
+        games = [
+            {"id": "a", "nextSession": (now + timedelta(days=2)).isoformat()},
+            {"id": "b", "nextSession": (now + timedelta(days=10)).isoformat()},
+            {"id": "c", "nextSession": (now - timedelta(days=1)).isoformat()},
+        ]
+        out = filter_games_in_lookahead(games, now=now, days=7)
+        self.assertEqual([g["id"] for g in out], ["a"])
+
+
+class FormatTests(unittest.TestCase):
+    def test_add_with_channel_and_games(self):
+        msg = format_adjustment_message(
+            action="add",
+            label="Dragon Delves",
+            general_channel_id="1391218431243714683",
+            upcoming_games=[
+                {
+                    "title": "Dragon Delves - A Baker's Doesn't",
+                    "nextSession": "2026-08-28T22:00:00.000Z",
+                }
+            ],
+        )
+        self.assertIn("**Added:** Dragon Delves", msg)
+        self.assertIn("**Gained access to:** <#1391218431243714683>", msg)
+        self.assertIn("**Open games (next 7 days):**", msg)
+        self.assertIn("Dragon Delves - A Baker's Doesn't", msg)
+        self.assertIn("<t:", msg)
+
+    def test_remove_no_games(self):
+        msg = format_adjustment_message(
+            action="remove",
+            label="Pirate Borg",
+            general_channel_id="1322063509718302730",
+        )
+        self.assertIn("**Removed:** Pirate Borg", msg)
+        self.assertIn("**Lost access to:** <#1322063509718302730>", msg)
+        self.assertNotIn("Open games", msg)
+
+    def test_add_omits_empty_sections(self):
+        msg = format_adjustment_message(action="add", label="Ten Candles", general_channel_id="")
+        self.assertEqual(msg, "**Added:** Ten Candles")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/roles.sh
+++ b/tools/roles.sh
@@ -112,6 +112,103 @@ print(json.dumps(payload, indent=2))
   return 1
 }
 
+# Soft-fail Zordon API GET (returns [] on failure)
+zordon_get() {
+  local endpoint="$1"
+  if [[ -z "${ZORDON_API_URL:-}" || -z "${ZORDON_API_KEY:-}" ]]; then
+    echo "[]"
+    return 0
+  fi
+  curl -sfk --connect-timeout 5 --max-time 15 \
+    -H "Authorization: Bearer ${ZORDON_API_KEY}" \
+    -H "Accept: application/json" \
+    "${ZORDON_API_URL}${endpoint}" 2>/dev/null || echo "[]"
+}
+
+emit_adjustment_result() {
+  local action="$1"
+  local caller_id="$2"
+  local role_id="$3"
+  local role_label="$4"
+  local general_ch="$5"
+  local upcoming_json="${6:-[]}"
+
+  ACTION="$action" CALLER_ID="$caller_id" ROLE_ID="$role_id" \
+    ROLE_LABEL="$role_label" GENERAL_CH="$general_ch" \
+    UPCOMING_JSON="$upcoming_json" run_py <<'PY'
+import json, os
+from games import format_adjustment_message
+
+action = os.environ["ACTION"]
+label = os.environ["ROLE_LABEL"]
+channel = os.environ.get("GENERAL_CH") or ""
+try:
+    upcoming = json.loads(os.environ.get("UPCOMING_JSON") or "[]")
+    if not isinstance(upcoming, list):
+        upcoming = []
+except Exception:
+    upcoming = []
+
+message = format_adjustment_message(
+    action=action,
+    label=label,
+    general_channel_id=channel,
+    upcoming_games=upcoming if action == "add" else None,
+)
+print(json.dumps({
+    "ok": True,
+    "action": action,
+    "userId": os.environ["CALLER_ID"],
+    "roleId": os.environ["ROLE_ID"],
+    "label": label,
+    "generalChannelId": channel,
+    "upcomingGames": upcoming if action == "add" else [],
+    "message": message,
+}, indent=2))
+PY
+}
+
+lookup_upcoming_for_role() {
+  local role_id="$1"
+  local channels_json schedule_json
+  channels_json=$(zordon_get "/channels")
+  schedule_json=$(zordon_get "/games/schedule?days=7")
+  ROLE_ID="$role_id" CHANNELS_JSON="$channels_json" SCHEDULE_JSON="$schedule_json" run_py <<'PY'
+import json, os
+from games import filter_games_in_lookahead, match_games_to_role_ids
+
+def as_list(raw):
+    try:
+        data = json.loads(raw or "[]")
+    except Exception:
+        return []
+    if isinstance(data, list):
+        return data
+    if isinstance(data, dict):
+        for key in ("channels", "games", "sessions", "schedule", "data"):
+            if isinstance(data.get(key), list):
+                return data[key]
+    return []
+
+role_id = os.environ["ROLE_ID"]
+mappings = as_list(os.environ.get("CHANNELS_JSON"))
+games = as_list(os.environ.get("SCHEDULE_JSON"))
+# schedule endpoint already filters days, but keep lookahead for safety
+matched = match_games_to_role_ids(games, mappings, [role_id])
+matched = filter_games_in_lookahead(matched)
+# slim payload for the agent
+slim = []
+for g in matched:
+    slim.append({
+        "id": g.get("id"),
+        "title": g.get("title"),
+        "nextSession": g.get("nextSession"),
+        "system": (g.get("system") or {}).get("name") if isinstance(g.get("system"), dict) else g.get("systemName"),
+    })
+print(json.dumps(slim))
+PY
+}
+
 case "$ACTION" in
   catalog)
     run_py <<'PY'
@@ -232,24 +329,8 @@ PY
         [[ -n "$DISCORD_RESP" ]] && echo "$DISCORD_RESP"
         exit 1
       fi
-      GENERAL_CH="$GENERAL_CH" ROLE_LABEL="$ROLE_LABEL" ROLE_ID="$ROLE_ID" CALLER_ID="$CALLER_ID" run_py <<'PY'
-import json, os
-channel = os.environ.get("GENERAL_CH") or ""
-label = os.environ["ROLE_LABEL"]
-msg = f"Added **{label}**."
-if channel:
-    msg += f" You should now see <#{channel}>."
-msg += " Use `/get-roles` anytime to manage game roles."
-print(json.dumps({
-    "ok": True,
-    "action": "add",
-    "userId": os.environ["CALLER_ID"],
-    "roleId": os.environ["ROLE_ID"],
-    "label": label,
-    "generalChannelId": channel,
-    "message": msg,
-}, indent=2))
-PY
+      UPCOMING=$(lookup_upcoming_for_role "$ROLE_ID" || echo "[]")
+      emit_adjustment_result add "$CALLER_ID" "$ROLE_ID" "$ROLE_LABEL" "$GENERAL_CH" "$UPCOMING"
     else
       set +e
       DISCORD_RESP=$(discord_request DELETE "/guilds/${GUILD_ID}/members/${CALLER_ID}/roles/${ROLE_ID}")
@@ -259,23 +340,7 @@ PY
         [[ -n "$DISCORD_RESP" ]] && echo "$DISCORD_RESP"
         exit 1
       fi
-      GENERAL_CH="$GENERAL_CH" ROLE_LABEL="$ROLE_LABEL" ROLE_ID="$ROLE_ID" CALLER_ID="$CALLER_ID" run_py <<'PY'
-import json, os
-channel = os.environ.get("GENERAL_CH") or ""
-label = os.environ["ROLE_LABEL"]
-msg = f"Removed **{label}**."
-if channel:
-    msg += f" You may lose access to <#{channel}>."
-print(json.dumps({
-    "ok": True,
-    "action": "remove",
-    "userId": os.environ["CALLER_ID"],
-    "roleId": os.environ["ROLE_ID"],
-    "label": label,
-    "generalChannelId": channel,
-    "message": msg,
-}, indent=2))
-PY
+      emit_adjustment_result remove "$CALLER_ID" "$ROLE_ID" "$ROLE_LABEL" "$GENERAL_CH" "[]"
     fi
     ;;
 


### PR DESCRIPTION
## Summary
- `roles.sh` add/remove `message` mirrors Zordon role menus: **Added/Removed**, **Gained/Lost access**, optional **Open games (next 7 days)**
- Matching uses the same title/system rules as `matchGamesToRoleIds`
- Soft-fail if Zordon API is missing

## Test plan
- [x] unit tests for match/format
- [ ] live add after bot hierarchy fix

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Discord role writes are unchanged; new behavior is reply copy and optional read-only Zordon API calls that soft-fail without blocking adds.
> 
> **Overview**
> **Add/remove success messages** now match the `/get-roles` role-menu bot instead of short one-liners. `roles.sh` builds the tool `message` via new `lib/games.py`: **Added/Removed**, optional **Gained/Lost access to** channel mentions, and on **add** only an optional **Open games (next 7 days)** block with Discord timestamps.
> 
> After a successful **add**, the script soft-fetches Zordon `/channels` and `/games/schedule?days=7` (empty if `ZORDON_API_*` is missing or the call fails), matches sessions to the role using the same title/system rules as Zordon role menus, and folds matches into the JSON (`upcomingGames` + `message`). **Remove** uses the same formatter without games.
> 
> **SKILL.md** tells the agent to post `message` **as-is**—no rewrites, no invented games, no separate `zordon-api` hop for schedule hints.
> 
> Unit tests cover matching, the 7-day window, and message formatting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c2009ee0ff315f1db39b8c57eff19bc1aff387a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->